### PR TITLE
Add blue ribbon variant of the small StepProgress

### DIFF
--- a/src/components/Section.vue
+++ b/src/components/Section.vue
@@ -1,18 +1,20 @@
 <template>
-    <section class="base n-style" v-bind:class="[theme, { vfill: verticalFill, padded: !noPad }]">
-        <template v-if="noGrid">
+    <section class="base n-style" v-bind:class="[theme, { vfill: verticalFill, padded: !noPad, 'suppress-divider': suppressDivider }]">
+
+        <template v-if="noContainer">
             <slot></slot>
         </template>
+
         <template v-else>
             <b-container :fluid="fluid">
                 <b-row>
-                    <b-col>
+                    <b-col :class="{ 'full-width': fullWidth }">
                         <slot></slot>
                     </b-col>
                 </b-row>
             </b-container>
         </template>
-        
+
     </section>
 </template>
 
@@ -33,10 +35,12 @@ export default Vue.extend({
             default: 'white',
         },
         verticalFill: Boolean,
-        noGrid: Boolean,
+        noContainer: Boolean,
         slim: Boolean,
         fluid: Boolean,
         noPad: Boolean,
+        suppressDivider: Boolean,
+        fullWidth: Boolean,
     },
 });
 </script>
@@ -56,7 +60,7 @@ export default Vue.extend({
     }
 }
 
-.white + .white .container::before {
+.white + .white .container::before:not(.suppress-divider) {
     content: "--------------";
     color: transparent;
     border-top: 4px solid $color-lightgrey;
@@ -106,6 +110,11 @@ export default Vue.extend({
 
 .padded {
     padding: 5em 0;
+}
+
+.full-width {
+    padding-left: 0;
+    padding-right: 0;
 }
 
 </style>

--- a/src/components/step/Progress.vue
+++ b/src/components/step/Progress.vue
@@ -1,18 +1,20 @@
 <template>
-    <div class="step-progress-container">
+    <div :class="['step-progress-container', variant]">
         <div class="step-progress-step" v-for="step in steps" :key="step.key" :class="{ active: isActive(step) }">
-            <div class="step-progress-content" :class="{ small, hand: clickable }" @click="clickStep(step)">
+            <div class="step-progress-content" :class="{ hand: clickable }" @click="clickStep(step)">
                 <slot name="text" :step="step">
                     <span>{{ step.title }}</span>
                 </slot>
             </div>
-            <div class="step-progress-divider align-self-center" :class="{ small }" v-if="showTail(step)">›</div>
+            <div class="step-progress-divider align-self-center" v-if="showTail(step)">›</div>
         </div>
     </div>
 </template>
 
 <script lang="ts">
 import Vue from 'vue';
+
+const variants : string[] = ['standard', 'light-step', 'blue-ribbon'];
 
 interface IStep {
     key: string | number,
@@ -31,9 +33,10 @@ export default Vue.extend({
             type: Array as () => IStep[],
             default: [],
         },
-        small: {
-            type: Boolean,
-            default: false,
+        variant: {
+            type: String,
+            default: 'standard',
+            validator: (value: string) => variants.indexOf(value) !== -1,
         },
         clickable: {
             type: Boolean,
@@ -61,6 +64,15 @@ export default Vue.extend({
             this.$emit('click', step);
         }
     },
+
+    computed: {
+        classObject(): any {
+            const result: any = {};
+            result[this.variant] = true;
+            result['hand'] = this.clickable;
+            return result;
+        }
+    }
 });
 </script>
 
@@ -68,11 +80,6 @@ export default Vue.extend({
 
 @import '../../assets/scss/base/vars.scss';
 @import '../../assets/scss/base/colors.scss';
-
-.step-progress-container {
-    display: flex;
-    justify-content: center;
-}
 
 $passive: $color-beige;
 $active: $color-orange;
@@ -82,50 +89,88 @@ $active: $color-orange;
     border-color: $color;
 }
 
-.step-progress-step {
+.step-progress-container {
     display: flex;
-    
-    .step-progress-content {
-        flex: 1;
-        min-width: 12em;
-        background-color: transparent;
-        border: $button-border-width solid $color-white;
-        padding: 0.7em;
-        text-align: center;
-        font-weight: 700;
-        color: $color-white;
+    justify-content: center;
 
-        &.small {
+    .step-progress-step {
+        display: flex;
+        
+        .step-progress-content {
+            flex: 1;
+            min-width: 12em;
+            background-color: transparent;
+            border: $button-border-width solid $color-white;
+            padding: 0.7em;
+            text-align: center;
+            font-weight: 700;
+            color: $color-white;
+
+            &.hand {
+                cursor: pointer;
+            }
+        }
+
+        &.active .step-progress-content {
+            background-color: $active;
+            border-color: $active;
+        }
+
+        .step-progress-divider {
+            margin: 0 0.5em;
+            font-weight: normal;
+            font-size: 30px;
+        }
+    }
+
+    // Variant light-step
+    &.light-step {
+        .step-progress-divider {
+            font-size: 20px;
+        }
+
+        .step-progress-step.active .step-progress-content {
+            background-color: transparent;
+            border-bottom: 2px solid $color-rose;
+        }
+
+        .step-progress-content {
             font-size: 0.9em;
             border: none;
             padding: 0.7em;
             min-width: 0;
         }
-
-        &.hand {
-            cursor: pointer;
-        }
     }
 
-    &.active .step-progress-content {
-        background-color: $active;
-        border-color: $active;
+    // Variant blue-ribbon
+    &.blue-ribbon {
 
-        &.small {
-            background-color: transparent;
-            border-bottom: 2px solid $color-rose;
-        }
-    }
+        background-color: $color-lightgrey;
 
-    .step-progress-divider {
-        margin: 0 0.5em;
-        font-weight: normal;
-        font-size: 30px;
-
-        &.small {
+        .step-progress-divider {
             font-size: 20px;
+            position: relative;
+            top: -2px;
+        }
+
+        .step-progress-step.active .step-progress-content {
+            background-color: transparent;
+            color: $color-white;
+            border-bottom: 5px solid $color-white;
+        }
+
+        .step-progress-content {
+            font-size: 0.9em;
+            border: none;
+            padding: 1.1em 0.7em 0.8em 0.7em;
+            min-width: 0;
         }
     }
+}
+
+section:not(.full-width) .step-progress-container.blue-ribbon {
+    margin-left: -15px;
+    margin-right: -15px;
 }
 
 section.white .step-progress-step {
@@ -135,26 +180,27 @@ section.white .step-progress-step {
         color: $color-darkblue;
     }
 
-    &.active .step-progress-content:not(.small) {
+    &.active .step-progress-container.standard .step-progress-content {
         @include back-and-border($color-darkblue);
         color: $color-white;
     }
 }
 
-section.darkblue .step-progress-step.active .step-progress-content:not(.small) {
+section.darkblue .step-progress-container.standard .step-progress-step.active .step-progress-content {
     @include back-and-border($color-lightgrey);
 }
 
-section.darkred .step-progress-step.active .step-progress-content:not(.small) {
+section.darkred .step-progress-container.standard .step-progress-step.active .step-progress-content {
     @include back-and-border($color-rose);
 }
 
-section.lightgrey .step-progress-step.active .step-progress-content:not(.small) {
+section.lightgrey .step-progress-container.standard .step-progress-step.active .step-progress-content {
     @include back-and-border($color-darkblue);
 }
 
-section.rose .step-progress-step.active .step-progress-content:not(.small) {
+section.rose .step-progress-container.standard .step-progress-step.active .step-progress-content {
     @include back-and-border($color-darkblue);
 }
+
 
 </style>

--- a/src/demo/examples/Progress.vue
+++ b/src/demo/examples/Progress.vue
@@ -1,13 +1,15 @@
 <template>
     <div>
-        <h2>StepProgress</h2>
+    
+        <n-section>
+            <h2>StepProgress</h2>
 
-        <p>
-            A component of a wizard or step flow, this is a visual aid showing all steps and
-            the current step being shown.
-        </p>
+            <p>
+                A component of a wizard or step flow, this is a visual aid showing all steps and
+                the current step being emphasized.
+            </p>
 
-        <h3>Basic usage</h3>
+            <h3>Basic usage</h3>
 
 <d-helpers-highlight lang="html">
 &lt;n-step-progress
@@ -32,68 +34,84 @@
 /&gt;
 </d-helpers-highlight>
 
-        <h3>Example</h3>
+            <h3>Example</h3>
 
-        <n-step-progress 
-            :steps="steps" 
-            :active="activeStep" 
-            clickable 
-            @click="stepClick" 
-        />
+            <n-step-progress 
+                :steps="steps" 
+                :active="activeStep" 
+                clickable 
+                @click="stepClick" 
+            />
 
-        <n-step-progress 
-            :steps="steps" 
-            :active="activeStep" 
-            small 
-            class="mt-5"
-            clickable
-            @click="stepClick"
-        >
+            <n-step-progress 
+                :steps="steps" 
+                :active="activeStep" 
+                variant="light-step"
+                class="mt-5"
+                clickable
+                @click="stepClick"
+            >
 
-            <span slot="text" slot-scope="{ step }">
-                <span>Tests {{ step.key }}</span>
-            </span>
+                <span slot="text" slot-scope="{ step }">
+                    <span>Tests {{ step.key }}</span>
+                </span>
 
-        </n-step-progress>
+            </n-step-progress>
 
-        <h3>Properties</h3>
+        </n-section>
 
-        <d-helpers-property-table :items="[
-            {
-                name: '@click',
-                type: '(step: IStep) => void',
-                default: 'null',
-                description: 'Event handler for the click event on the progress.',
-            },
-            {
-                name: 'active',
-                type: 'IStep | string',
-                default: 'null',
-                description: 'The active step, as a reference to the actual object or the key as a string.',
-            },
-            {
-                name: 'clickable',
-                type: 'boolean',
-                default: 'false',
-                description: 'Activated as clickable, which will activate the event handler and apply a hand cursor.',
-            },
-            {
-                name: 'small',
-                type: 'boolean',
-                default: 'false',
-                description: 'A smaller variant for sub-steps or a higher quantity of steps.'
-            },
-            {
-                name: 'steps',
-                type: 'IStep[]',
-                default: '[]',
-                description: 'An array describing the step keys and titles.'
-            },
-        ]"/>
+        <n-section fluid>
 
-        <h3><code>IStep</code> interface</h3>
+            <n-step-progress
+                :steps="steps"
+                :active="activeStep"
+                variant="blue-ribbon"
+                clickable
+                @click="stepClick"
+            />
 
-        <p>The key of <code>IStep</code> should be unique.</p>
+        </n-section>
+
+        <n-section suppress-divider>
+
+            <h3>Properties</h3>
+
+            <d-helpers-property-table :items="[
+                {
+                    name: '@click',
+                    type: '(step: IStep) => void',
+                    default: 'null',
+                    description: 'Event handler for the click event on the progress.',
+                },
+                {
+                    name: 'active',
+                    type: 'IStep | string',
+                    default: 'null',
+                    description: 'The active step, as a reference to the actual object or the key as a string.',
+                },
+                {
+                    name: 'clickable',
+                    type: 'boolean',
+                    default: 'false',
+                    description: 'Activated as clickable, which will activate the event handler and apply a hand cursor.',
+                },
+                {
+                    name: 'variant',
+                    type: 'string',
+                    default: 'standard',
+                    description: '&quot;standard&quot;, &quot;light-step&quot; or &quot;blue-ribbon&quot; showed in examples above. Note that &quot;blue-ribbon&quot; should be placed in a fluid section to display full width.'
+                },
+                {
+                    name: 'steps',
+                    type: 'IStep[]',
+                    default: '[]',
+                    description: 'An array describing the step keys and titles.'
+                },
+            ]"/>
+
+            <h3><code>IStep</code> interface</h3>
+
+            <p>The key of <code>IStep</code> should be unique.</p>
 
 <d-helpers-highlight lang="typescript">
 {
@@ -102,17 +120,18 @@
 }
 </d-helpers-highlight>
 
-        <h3>Slots</h3>
+            <h3>Slots</h3>
 
-        <d-helpers-slot-table
-            :items="[
-                {
-                    name: 'text',
-                    scope: 'step: IStep',
-                    description: 'Provide a template for the inner rendering of the item text. Default is the title in a <span>.',
-                }
-            ]"
-        />
+            <d-helpers-slot-table
+                :items="[
+                    {
+                        name: 'text',
+                        scope: 'step: IStep',
+                        description: 'Provide a template for the inner rendering of the item text. Default is the title in a <span>.',
+                    }
+                ]"
+            />
+        </n-section>
     </div>
 </template>
 

--- a/src/demo/views/Components.vue
+++ b/src/demo/views/Components.vue
@@ -110,9 +110,7 @@
 			<d-examples-wait />
 		</n-section>		
 
-		<n-section>
-			<d-examples-progress />
-		</n-section>
+		<d-examples-progress />
 
 		<n-section>
 			<d-examples-dot-progress />

--- a/src/demo/views/Structure.vue
+++ b/src/demo/views/Structure.vue
@@ -269,6 +269,12 @@ export default Vue.extend({
         description: 'Whether the embedded bootstrap grid should be fluid. Ignored when the no-container option is on.',
       },
       {
+        name: 'full-width',
+        type: 'bool',
+        default: 'false',
+        description: 'If set, the section will have no side padding, and will fill up the entire width.'
+      },
+      {
         name: 'no-container',
         type: 'bool',
         default: 'false',


### PR DESCRIPTION
![](https://i.imgur.com/nVZxiAf.png)

Fixes #12.

Another variant of the StepProgress called a `blue-ribbon` variant.

To be used properly, the new variant needs to be inserted into a "fluid" section. A normal section will not use the full width.

```vue
<n-section fluid>

  <n-step-progress
    :steps="steps"
    :active="activeStep"
    variant="blue-ribbon"
    clickable
    @click="stepClick"
  />

</n-section>
```

_This is a breaking change_. Since the only variant before was `small` (as a flag attribute on the element), with the introduction of a third variant I opted for changing the API. Instead of setting or omitting the `small` attribute, we now have a `variant` attribute that can be set to `standard` (default), `light-step` (the former small) or `blue-ribbon` (the new one).

When updating to this version, all instances of `<n-step-progress small />` need to be changed to `<n-step-progress variant="light-step" />`.