### PR TITLE
Introduce a lightgrey variant of the footer

### DIFF
--- a/src/components/Footer.vue
+++ b/src/components/Footer.vue
@@ -1,5 +1,5 @@
 <template>
-    <footer class="standard">
+    <footer :class="['n-footer', variant]">
         <b-container>
             <slot></slot>
         </b-container>
@@ -10,23 +10,37 @@
 import Vue from 'vue';
 import { BContainer } from 'bootstrap-vue';
 
+const variants : string[] = ['darkblue', 'lightgrey'];
+
 export default Vue.extend({
     components: {
         'b-container': BContainer,
+    },
+    props: {
+        variant: {
+            type: String,
+            default: 'darkblue',
+            validator: (value: string) => variants.indexOf(value) !== -1,
+        }
     }
 })
 </script>
 
-
 <style lang="scss" scoped>
 @import '../assets/scss/base/colors.scss';
 
-
-.standard {
+.n-footer {
     font-family: 'Nationale';
 
-    background-color: $color-darkblue;
-    color: $color-white;
+    &.darkblue {
+        background-color: $color-darkblue;
+        color: $color-white;
+    }
+
+    &.lightgrey {
+        background-color: $color-lightgrey;
+        color: $color-white;
+    }
 
     padding: 4em 0;
 

--- a/src/demo/DemoApp.vue
+++ b/src/demo/DemoApp.vue
@@ -17,7 +17,7 @@
       
     </n-nav-topbar>
     <router-view />
-    <n-footer>
+    <n-footer variant="darkblue">
       <b-row>
         <b-col><img src="../assets/images/BL.svg" style="width: 120px" /></b-col>
         <b-col><n-logo white :width="100" /></b-col>


### PR DESCRIPTION
Fixes #5.

The footer can be used by adding a variant.

```vue
<n-footer variant="lightgrey">
  ...
</n-footer>
```

![](https://i.imgur.com/Gb01YgA.png)